### PR TITLE
fix: condition for lin_mask with 2 rows/columns

### DIFF
--- a/blended_tiling/tiling_module.py
+++ b/blended_tiling/tiling_module.py
@@ -148,7 +148,7 @@ class TilingModule(torch.nn.Module):
                 i = len(coords) - 1
                 zeros_size = ((coords[i - 1] + tile_dim) - lin_size) - coords[i]
                 # Only use lin_mask for a row / column of 2 with equal overlap
-                if tile_dim > d / 2 and tile_dim != d:
+                if c == 1 and tile_dim > d / 2 and tile_dim != d:
                     lin_size = lin_size + zeros_size
                     zeros_size = 0
                 ovlp = [zeros_size, lin_size]

--- a/tests/test_tiling_module.py
+++ b/tests/test_tiling_module.py
@@ -613,7 +613,40 @@ class TestTilingModule(BaseTest):
             def forward(self, x: torch.Tensor) -> torch.Tensor:
                 x = self.rebuild_with_masks(x)
                 x = self.custom_module(x) + 4.0
-                return self._get_tiles_and_coords(full_tensor)[0]
+                return self._get_tiles_and_coords(x)[0]
+
+        tiling_module = CustomTilingModule(
+            tile_size=tile_size,
+            tile_overlap=tile_overlap,
+            base_size=full_size,
+        )
+
+        num_tiles = tiling_module.num_tiles()
+        x = torch.ones([tiling_module.num_tiles(), 3] + tile_size)
+        output = tiling_module(x)
+
+        self.assertEqual(list(output.shape), [num_tiles, 3] + tile_size)
+        assertTensorAlmostEqual(self, output, x + 4.0, delta=0.003)
+
+    def test_forward_barely_more_than_two_tiles(self) -> None:
+        full_size = [416, 416]
+        tile_size = [224, 224]
+        tile_overlap = [0.25, 0.25]
+
+        class CustomTilingModule(TilingModule):
+            def __init__(
+                self,
+                tile_size = [224, 224],
+                tile_overlap = [0.25, 0.25],
+                base_size = [512, 512],
+            ) -> None:
+                TilingModule.__init__(self, tile_size, tile_overlap, base_size)
+                self.custom_module = torch.nn.Identity()
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                x = self.rebuild_with_masks(x)
+                x = self.custom_module(x) + 4.0
+                return self._get_tiles_and_coords(x)[0]
 
         tiling_module = CustomTilingModule(
             tile_size=tile_size,


### PR DESCRIPTION
### Bug fix

when the image size is barely larger than two tiles, the `# Only use lin_mask for a row / column of 2 with equal overlap` condition should not be met.

Before fix: 
![sjfusion_2_after_tiling](https://github.com/ProGamerGov/blended-tiling/assets/129726301/a77668ac-f001-418a-b753-675ebe7658e9)


After:
![sjfusion_2_after_tiling_fixed](https://github.com/ProGamerGov/blended-tiling/assets/129726301/11bddb19-e664-4ec0-83db-ab0bccf76293)
